### PR TITLE
Return win32yank; else CheckHealth reports failure

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -78,6 +78,11 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'doitclient'
+  elseif executable('win32yank')
+    let s:copy['+'] = 'win32yank -i --crlf'
+    let s:paste['+'] = 'win32yank -o --lf'
+    let s:copy['*'] = s:copy['+']
+    let s:paste['*'] = s:paste['+']
   endif
 
   let s:err = 'clipboard: No clipboard tool available. See :help clipboard'

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -83,6 +83,7 @@ function! provider#clipboard#Executable() abort
     let s:paste['+'] = 'win32yank -o --lf'
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
+    return 'win32yank'
   endif
 
   let s:err = 'clipboard: No clipboard tool available. See :help clipboard'

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -292,18 +292,41 @@ target_link_libraries(nvim ${NVIM_EXEC_LINK_LIBRARIES})
 install_helper(TARGETS nvim)
 
 if(WIN32)
-  # Copy DLLs to bin/ and install them along with nvim
-  add_custom_target(nvim_dll_deps ALL DEPENDS nvim
+  # Copy DLLs and third-party tools to bin/ and install them along with nvim
+  add_custom_target(nvim_runtime_deps ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  foreach(BIN win32yank.exe)
+    unset(BIN_PATH CACHE)
+    find_program(BIN_PATH ${BIN})
+    if(NOT BIN_PATH)
+      message(FATAL_ERROR "Unable to find external dependency ${BIN}")
+      continue()
+    endif()
+
+    add_custom_target(external_${BIN}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps
+      COMMAND ${CMAKE_COMMAND}
+        "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+        -DBINARY="${BIN_PATH}"
+        -DDST=${PROJECT_BINARY_DIR}/windows_runtime_deps
+        -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake
+      COMMAND ${CMAKE_COMMAND} -E copy ${BIN_PATH} ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+      COMMENT "${BIN_PATH}")
+    add_dependencies(nvim_runtime_deps "external_${BIN}")
+  endforeach()
+
+  add_custom_target(nvim_dll_deps DEPENDS nvim
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps
     COMMAND ${CMAKE_COMMAND}
       "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
       -DBINARY="${PROJECT_BINARY_DIR}/bin/nvim${CMAKE_EXECUTABLE_SUFFIX}"
       -DDST=${PROJECT_BINARY_DIR}/windows_runtime_deps
-      -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps/
-      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  install(DIRECTORY ${PROJECT_BINARY_DIR}/windows_runtime_deps/
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+      -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake)
+  add_dependencies(nvim_runtime_deps nvim_dll_deps)
 endif()
 
 if(CLANG_ASAN_UBSAN)

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -5,8 +5,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect, eq, eval = helpers.execute, helpers.expect, helpers.eq, helpers.eval
 
-if helpers.pending_win32(pending) then return end
-
 local function basic_register_test(noblock)
   insert("some words")
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -174,3 +174,11 @@ add_custom_target(clean-shared-libraries
 add_custom_target(third-party ALL
   COMMAND ${CMAKE_COMMAND} -E touch .third-party
   DEPENDS clean-shared-libraries)
+
+if(WIN32)
+  set(WIN32YANK_URL https://github.com/equalsraf/win32yank/releases/download/v0.0.2/win32yank.zip)
+  set(WIN32YANK_SHA256 78869bf68565607cda1b6a3d549e2487d59d6f0f16f9b003e123c0086f90309d)
+
+  include(GetWindowsDeps)
+endif()
+

--- a/third-party/cmake/GetWindowsDeps.cmake
+++ b/third-party/cmake/GetWindowsDeps.cmake
@@ -1,0 +1,43 @@
+# Download and install binary dependencies for windows
+include(CMakeParseArguments)
+
+# This is similar to the build recipes, but instead downloads a third party
+# binaries and installs it under the the DEPS_PREFIX.
+function(GetWindowsDep)
+  cmake_parse_arguments(_gettool
+    "BUILD_IN_SOURCE"
+    "TARGET"
+    "INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _gettool_TARGET OR NOT _gettool_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass INSTALL_COMMAND and TARGET")
+  endif()
+
+  string(TOUPPER "${_gettool_TARGET}_URL" URL_VNAME)
+  string(TOUPPER "${_gettool_TARGET}_SHA256" HASH_VNAME)
+  set(URL ${${URL_VNAME}})
+  set(HASH ${${HASH_VNAME}})
+  if(NOT URL OR NOT HASH )
+	  message(FATAL_ERROR "${URL_VNAME} and ${HASH_VNAME} must be set")
+  endif()
+
+  ExternalProject_Add(${_gettool_TARGET}
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}
+      -DURL=${URL}
+      -DEXPECTED_SHA256=${HASH}
+      -DTARGET=${_gettool_TARGET}
+      -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND "${_gettool_INSTALL_COMMAND}")
+  list(APPEND THIRD_PARTY_DEPS ${__gettool_TARGET})
+endfunction()

--- a/third-party/cmake/GetWindowsDeps.cmake
+++ b/third-party/cmake/GetWindowsDeps.cmake
@@ -41,3 +41,9 @@ function(GetWindowsDep)
     INSTALL_COMMAND "${_gettool_INSTALL_COMMAND}")
   list(APPEND THIRD_PARTY_DEPS ${__gettool_TARGET})
 endfunction()
+
+GetWindowsDep(TARGET win32yank
+  INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/bin
+    COMMAND ${CMAKE_COMMAND} -E copy 
+             ${DEPS_BUILD_DIR}/src/win32yank/win32yank.exe
+	     ${DEPS_INSTALL_DIR}/bin)


### PR DESCRIPTION
Tried the build from appveyor but kept getting errors on startup and running `CheckHealth` reported no clipboard provider even though `executable('win32yank')` was 1. Turned out that provider string has to be returned.